### PR TITLE
Rename status_url to status-url

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -26,14 +26,14 @@
       github:
         status: success
         comment: false
-        status_url: &log_link "https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.ref}/"
+        status-url: &log_link "https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.ref}/"
     failure:
       gerrithub:
         verified: -1
       github:
         status: failure
         comment: true
-        status_url: *log_link
+        status-url: *log_link
 
 - pipeline:
     name: gate
@@ -65,13 +65,13 @@
       github:
         status: success
         comment: false
-        status_url: *log_link
+        status-url: *log_link
         merge: false
     failure:
       github:
         status: failure
         comment: true
-        status_url: *log_link
+        status-url: *log_link
 
 - job:
     name: base


### PR DESCRIPTION
The code that ended up commited to zuul used status-url instead of
status_url so update our project_config to match this.

Change-Id: Ida4b3ac76b742a8988555e8f4013bb9f63eb73b1
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>