### PR TITLE
Specify require by source

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -54,9 +54,10 @@
           action: dismissed
           state: request_changes
     require:
-      status: "bonnyci[bot]:check:success"
-      approval:
-        - review: 2
+      github:
+        status: "bonnyci[bot]:check:success"
+        approval:
+          - review: 2
     start:
       github:
         status: pending


### PR DESCRIPTION
Seems that newer versions of zuul.yaml require you to specify where a
requirement comes from. So we must add a github key to make this valid.

Change-Id: Iabc1d06928c43329bb6685c83dc621025437694c
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>