### PR TITLE
Use review requirement instead of approval

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -55,9 +55,10 @@
           state: request_changes
     require:
       github:
-        status: "bonnyci[bot]:check:success"
-        approval:
-          - review: 2
+        status:
+          - "bonnyci[bot]:check:success"
+        review:
+          - permission: write
     start:
       github:
         status: pending


### PR DESCRIPTION
We removed the approval field in zuul for github and replaced it with
the more specific review field. Adjust project-config to match.

Change-Id: I7c0f7a294dd0d0dc7955466801136c1ce514957c
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>