### PR TITLE
Use label not image in node selector

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -87,4 +87,4 @@
     parent: base
     nodes:
       - name: bonnyci
-        image: ubuntu-xenial
+        label: ubuntu-xenial


### PR DESCRIPTION
Zuul switched back to using the label terminology instead of image.
Update project-config to fix.

Change-Id: Ia955e91ebcf6e0b9b5f8889e7bfafc8ed6c36422
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>