### PR TITLE
Use buildset.uuid to build report urls

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -26,7 +26,7 @@
       github:
         status: success
         comment: false
-        status-url: &log_link "https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.ref}/"
+        status-url: &log_link "https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/"
     failure:
       gerrithub:
         verified: -1
@@ -79,7 +79,7 @@
     name: base
     pre-run: base-pre
     post-run: base-post
-    success-url: https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.ref}/{job.name}
+    success-url: https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/{job.name}
     timeout: 1800
 
 - job:


### PR DESCRIPTION
Buildset.ref was used in BonnyCI's fork for exposing a buildset
identifier. When merging it upstream it was decided it was better to
provide a buildset uuid for this function.

Now that the change has been merged upstream update our configuration to
match.

Change-Id: Ibd0ec05810df3392144955c72f33202f49571c1d
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>