### PR TITLE
Remove the console_log_file concept

### DIFF
--- a/playbooks/roles/base/tasks/post.yaml
+++ b/playbooks/roles/base/tasks/post.yaml
@@ -4,8 +4,6 @@
     src: "{{ item.src }}"
     mode: pull
   with_items:
-    - dest: "console.log"
-      src: "{{ base_console_log_file }}"
     - dest: logs
       src: "{{ base_log_root }}"
 

--- a/playbooks/roles/base/tasks/pre.yaml
+++ b/playbooks/roles/base/tasks/pre.yaml
@@ -1,11 +1,5 @@
-- name: Ensure console.log does not exist.
-  file:
-    path: "{{ base_console_log_file }}"
-    state: absent
-
 - name: Start zuul_console daemon.
   zuul_console:
-    path: "{{ base_console_log_file }}"
     port: "{{ base_console_log_port }}"
 
 - name: Create workspace and logging directories.

--- a/playbooks/roles/base/vars/main.yaml
+++ b/playbooks/roles/base/vars/main.yaml
@@ -1,4 +1,3 @@
-base_console_log_file: /tmp/console.log
 base_console_log_port: 19885
 
 base_log_root: "/home/zuul/logs"


### PR DESCRIPTION
Zuul used to operate with a single /tmp/console.log file, however has
recently switched to creating one file per task. This means we no longer
want to hard specify a single file in our pre and post jobs.

I think this means we then pick up the log file from the executor, but
i'll worry about that next.

Change-Id: I75fb8ea2ad40145dba34894f7beadd5db3d3d02a
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>