### PR TITLE
Use shell for local rsync command

### DIFF
--- a/playbooks/roles/base/tasks/post.yaml
+++ b/playbooks/roles/base/tasks/post.yaml
@@ -7,9 +7,11 @@
     - dest: logs
       src: "{{ base_log_root }}"
 
+# FIXME(jamielennox): switch back to command after command+delegate_to:
+# localhost work together correctly with zuul streaming.
 - name: publish logs.
   delegate_to: localhost
-  command: >
+  shell: >
     /usr/bin/rsync -q
     --compress --recursive
     --rsh ssh


### PR DESCRIPTION
The command module in zuul is overridden to do zuul streaming, but for
now this causes interesting problems with delegate_to: localhost. There
are possible fixes in places for this coming but for now see if the
problem can be fixed by using shell instead of command.

Change-Id: I288f4217368c5013cd7f53afbeb3ce86d6be8c53
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>