### PR TITLE
Revert "Use shell for local rsync command"

### DIFF
--- a/playbooks/roles/base/tasks/post.yaml
+++ b/playbooks/roles/base/tasks/post.yaml
@@ -7,11 +7,9 @@
     - dest: logs
       src: "{{ base_log_root }}"
 
-# FIXME(jamielennox): switch back to command after command+delegate_to:
-# localhost work together correctly with zuul streaming.
 - name: publish logs.
   delegate_to: localhost
-  shell: >
+  command: >
     /usr/bin/rsync -q
     --compress --recursive
     --rsh ssh


### PR DESCRIPTION
This reverts commit 7f110f90247e0e901abc3fe57094df7d835bd2a7.

Under the hood in ansible shell and command are the same thing with the
_uses_shell parameter added. So even after the change you hit the same
problems of using the command module.

Change-Id: Ieccf82071077c73bae9891f7b5b3f9c0dd6125fe
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>