### PR TITLE
Don't quiet rsync

### DIFF
--- a/playbooks/roles/base/tasks/post.yaml
+++ b/playbooks/roles/base/tasks/post.yaml
@@ -10,7 +10,7 @@
 - name: publish logs.
   delegate_to: localhost
   command: >
-    /usr/bin/rsync -q
+    /usr/bin/rsync
     --compress --recursive
     --rsh ssh
     --rsync-path 'mkdir -p /var/www/bonny-logs/logs/{{ zuul.tenant }}/{{ zuul.pipeline }}/{{ zuul.project.canonical_name }}/{{ zuul.change }}/{{ zuul.ref }}/{{ zuul.job }} && rsync'


### PR DESCRIPTION
There's something failing on the rsync command. I think it's probably to
do with the zuul streamer but let's remove the quiet flag for now so we
can see some output.

Change-Id: I1208ef52ca1aba1117c157b9ddbcc883ab5d057b
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>