### PR TITLE
Update pipelines for latest github support in zuul

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -2,6 +2,10 @@
     name: check
     manager: independent
     allow-secrets: True
+    require:
+      github:
+        open: true
+        current-patchset: true
     trigger:
       gerrithub:
         - event: patchset-created
@@ -55,10 +59,12 @@
           state: request_changes
     require:
       github:
-        status:
-          - "bonnyci[bot]:check:success"
+        open: true
+        current-patchset: true
+        status: "bonnyci[bot]:check:success"
         review:
-          - permission: write
+          - type: approved
+            permission: write
     start:
       github:
         status: pending


### PR DESCRIPTION
Require open/current-patchset on check and gate pipelines, and use the
new way to express a review requirement in the gate pipeline.

Signed-off-by: Jesse Keating <jkeating@j2solutions.net>