### PR TITLE
Don't use sudo when uploading playbooks

### DIFF
--- a/roles/base/tasks/post.yaml
+++ b/roles/base/tasks/post.yaml
@@ -8,6 +8,7 @@
       src: "{{ base_log_root }}"
 
 - name: publish logs.
+  become: no
   delegate_to: localhost
   command: >
     /usr/bin/rsync -vvv


### PR DESCRIPTION
I'm not sure if this is correct, however when we rsync from local to the
logs server we shouldn't need to use sudo.

Change-Id: Ied61d2239d6bdec4fe135e2588700f301bb40c59
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>