### PR TITLE
Use scp variables for upload job

### DIFF
--- a/roles/base/tasks/post.yaml
+++ b/roles/base/tasks/post.yaml
@@ -14,6 +14,6 @@
     /usr/bin/rsync -vvv
     --compress --recursive
     --rsh ssh
-    --rsync-path 'mkdir -p /var/www/bonny-logs/logs/{{ zuul.tenant }}/{{ zuul.pipeline }}/{{ zuul.project.canonical_name }}/{{ zuul.change }}/{{ zuul.ref }}/{{ zuul.job }} && rsync'
+    --rsync-path 'mkdir -p {{ bonnyci_logs_dir }}/{{ zuul.tenant }}/{{ zuul.pipeline }}/{{ zuul.project.canonical_name }}/{{ zuul.change }}/{{ zuul.ref }}/{{ zuul.job }} && rsync'
     {{ zuul.executor.log_root }}/
-    zuul@logs.opentechsjc.bonnyci.org:/var/www/bonny-logs/logs/{{ zuul.tenant }}/{{ zuul.pipeline }}/{{ zuul.project.canonical_name }}/{{ zuul.change }}/{{ zuul.ref }}/{{ zuul.job }}/
+    {{ bonnyci_logs_scp }}:{{ bonnyci_logs_dir }}/{{ zuul.tenant }}/{{ zuul.pipeline }}/{{ zuul.project.canonical_name }}/{{ zuul.change }}/{{ zuul.ref }}/{{ zuul.job }}/


### PR DESCRIPTION
Don't hardcode the logs server parameters, instead use variables
specified by the zuul deployment.

Change-Id: I98cfc7b1f32a7ba588ac1ca8488a64f967940b72
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>