### PR TITLE
Remove old .gitreview

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,4 +1,0 @@
-[gerrit]
-host=review.gerrithub.io
-port=29418
-project=BonnyCI/project-config-v3.git


### PR DESCRIPTION
Before we had github working correctly we had to host project-config on
gerrithub to make it work and so had a .gitreview. We don't need this
any more.

Change-Id: I81d36826fae5cbf88dc0489fd23fdc931ece2a55
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>