### PR TITLE
Add a path to the logs secrets

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -105,6 +105,7 @@
     name: bonnyci_log_ssh
     data:
       fqdn: logs.internal.opentech.bonnyci.org
+      path: /var/www/bonny-logs/logs
       ssh_username: zuul
       ssh_known_hosts: |
         logs.opentech.bonnyci.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgCFYYM9ue5xE17faGs/NwpLg8kgdI6PIa1XHsPZp3Sx/f/GNYSRUgwH94HQJiRRkZpxK640ESWCezOdTOkQbaIoUy4R+x5W/GlCzc+ZWFh18KkbSQgWkZeNoYDRmlykzLUwV5t82Absv14HHPRlwMn0rAjhIw2HnxIhxOptGI5dr4djluqT3lehTYoQeEgtjmRege9/4a9PJxz0be52kG3uu2v0XCEBCyvUTQgO6uw5LvclSfFeQbBz1B0XzrU6Z4RC1zSjXdTEeLJ6MZPz9V94Pq319B5DDdVCNKJKDNSjwks3GKgzA7UxcShs60TqzOIwMZAFPgoeGEyAaI3lGT


### PR DESCRIPTION
This doesn't really suit us, but the upstream setup role defines that we
specify a host parameter that will be consumed by a different role. At
the moment it doesn't affect us, but we have to define it.

Change-Id: I1413b3edcded4259af399976cc3fb66e4bc63d5f
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>