### PR TITLE
Make sure that logs ssh-key matches fqdn

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -108,7 +108,7 @@
       path: /var/www/bonny-logs/logs
       ssh_username: zuul
       ssh_known_hosts: |
-        logs.opentech.bonnyci.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgCFYYM9ue5xE17faGs/NwpLg8kgdI6PIa1XHsPZp3Sx/f/GNYSRUgwH94HQJiRRkZpxK640ESWCezOdTOkQbaIoUy4R+x5W/GlCzc+ZWFh18KkbSQgWkZeNoYDRmlykzLUwV5t82Absv14HHPRlwMn0rAjhIw2HnxIhxOptGI5dr4djluqT3lehTYoQeEgtjmRege9/4a9PJxz0be52kG3uu2v0XCEBCyvUTQgO6uw5LvclSfFeQbBz1B0XzrU6Z4RC1zSjXdTEeLJ6MZPz9V94Pq319B5DDdVCNKJKDNSjwks3GKgzA7UxcShs60TqzOIwMZAFPgoeGEyAaI3lGT
+        logs.internal.opentech.bonnyci.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgCFYYM9ue5xE17faGs/NwpLg8kgdI6PIa1XHsPZp3Sx/f/GNYSRUgwH94HQJiRRkZpxK640ESWCezOdTOkQbaIoUy4R+x5W/GlCzc+ZWFh18KkbSQgWkZeNoYDRmlykzLUwV5t82Absv14HHPRlwMn0rAjhIw2HnxIhxOptGI5dr4djluqT3lehTYoQeEgtjmRege9/4a9PJxz0be52kG3uu2v0XCEBCyvUTQgO6uw5LvclSfFeQbBz1B0XzrU6Z4RC1zSjXdTEeLJ6MZPz9V94Pq319B5DDdVCNKJKDNSjwks3GKgzA7UxcShs60TqzOIwMZAFPgoeGEyAaI3lGT
       ssh_private_key: !encrypted/pkcs1-oaep
         - KFJ9diCJ7ymteKKRIw2iHgfB8RSA8VoNGwbJYnQHjXAxGHTOC6GdhMv/JAabcHbi7EmNh
           0yQpKGPVayUfuACpJYQBDfzPGzcMMEkcddOgx0CNXcVZigSwglZ9hLvSNGCB7a8T4YeCz


### PR DESCRIPTION
We're having an ansible failure adding the ssh host keys. I think it's
because you must have the key name be present in the start of the host
key to add. Both should use the internal IP.

Change-Id: I7f8f81ec5d63747a6a55ee222891e07884d85ece
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>