### PR TITLE
Create full logging dir in publish

### DIFF
--- a/roles/base/tasks/publish.yaml
+++ b/roles/base/tasks/publish.yaml
@@ -1,6 +1,6 @@
 - name: Create log directories
   file:
-    path: "{{ bonnyci_logs_dir }}"
+    path: "{{ base_log_dir }}"
     state: directory
 
 - name: Upload logs


### PR DESCRIPTION
I thought it would be sufficient to make sure the base log directory is
in place and synchronize would create the rest. This appears to be
mistaken so just create the whole thing.

Change-Id: I533dc48d7ff56e3d1aa17aab6b9af0366c4b2f6a
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>