### PR TITLE
Reset log paths to the same place

### DIFF
--- a/roles/base/vars/main.yaml
+++ b/roles/base/vars/main.yaml
@@ -3,4 +3,4 @@ base_console_log_port: 19885
 base_log_root: "/home/zuul/logs"
 base_workspace_root: "/home/zuul/workspace"
 
-base_log_dir: "{{ bonnyci_logs_dir }}/{{ zuul.tenant }}/{{ zuul.pipeline }}/{{ zuul.project.canonical_name }}/{{ zuul.change }}/{{ zuul.ref }}/{{ zuul.job }}"
+base_log_dir: "{{ bonnyci_logs_dir }}/{{ zuul.tenant }}/{{ zuul.pipeline }}/{{ zuul.project.canonical_name }}/{{ zuul.change }}/{{ zuul.buildset }}/{{ zuul.job }}"

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -26,7 +26,7 @@
       github:
         status: success
         comment: false
-        status-url: &log_link "https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/"
+        status-url: &log_link "https://logs.opentech.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/"
     failure:
       gerrithub:
         verified: -1
@@ -89,7 +89,8 @@
     post-run: playbooks/base/post
     roles:
       - zuul: openstack-infra/zuul-jobs
-    success-url: https://logs.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/{job.name}
+    success-url: https://logs.opentech.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/{job.name}
+    failure-url: https://logs.opentech.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/{job.name}
     timeout: 1800
     secrets:
       - bonnyci_log_ssh


### PR DESCRIPTION
We have to point to opentech.bonnyci.org for a little while and we cant
use zuul.ref anymore as this looks like refs/pulls/1/head which is not a
useful distinguisher.

Change-Id: Idf1761a5f94f662773152014d47cfba293b16b0d
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>