### PR TITLE
Add nodes definition to base

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -94,13 +94,13 @@
     timeout: 1800
     secrets:
       - bonnyci_log_ssh
+    nodes:
+      - name: bonnyci
+        label: ubuntu-xenial
 
 - job:
     name: bonnyci
     parent: base
-    nodes:
-      - name: bonnyci
-        label: ubuntu-xenial
 
 - secret:
     name: bonnyci_log_ssh


### PR DESCRIPTION
When using upstream roles they have a reliance on the base node. This
means they expect a working node to be available on the base job, not on
the bonnyci job as it is now.

This is a little annoying that we can't attach jobs to something higher
than base, but just do it for now as it can be overriden later.

Change-Id: Idbcfbdf69ce7f6527f934ac82f543d699f80db25
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>