### PR TITLE
Use BonnyCI/zuul-jobs for now

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -88,7 +88,7 @@
     pre-run: playbooks/base/pre
     post-run: playbooks/base/post
     roles:
-      - zuul: openstack-infra/zuul-jobs
+      - zuul: BonnyCI/zuul-jobs
     success-url: https://logs.opentech.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/{job.name}
     failure-url: https://logs.opentech.bonnyci.org/{tenant.name}/{pipeline.name}/{change.project.canonical_name}/{change.number}/{buildset.uuid}/{job.name}
     timeout: 1800


### PR DESCRIPTION
Upstream is still too volatile. Use our own fork of zuul-jobs for
definitions for now.

Change-Id: I64e5971c0a06e26e8e35d81da869ba335669ed0e
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>