### PR TITLE
Move nodes into a nodeset key

### DIFF
--- a/zuul.yaml
+++ b/zuul.yaml
@@ -94,9 +94,10 @@
     timeout: 1800
     secrets:
       - bonnyci_log_ssh
-    nodes:
-      - name: bonnyci
-        label: ubuntu-xenial
+    nodeset:
+      nodes:
+        - name: bonnyci
+          label: ubuntu-xenial
 
 - job:
     name: bonnyci


### PR DESCRIPTION
as of https://review.openstack.org/#/c/505845 the "nodes" top level job
key is no longer valid, and it must be within a "nodeset" key.

Signed-off-by: Jesse Keating <jkeating@j2solutions.net>